### PR TITLE
Lock in version 1.0.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,8 +8,8 @@
     "mocha": "^2.2.4",
     "node-uuid": "^1.4.3",
     "should": "^6.0.1",
-    "socket.io": "^1.3.5",
-    "socket.io-client": "^1.3.5"
+    "socket.io": "~1.3.5",
+    "socket.io-client": "~1.3.5"
   },
   "devDependencies": {},
   "description": "A distributed API for closed captioning live-streams.",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opened-captions",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "dependencies": {
     "bluebird": "^2.9.25",
     "express": "^4.12.3",


### PR DESCRIPTION
This is a stale branch, but will get the master branch in line with what is currently published on npm.