### PR TITLE
Remove lodash

### DIFF
--- a/lib/opened-captions.js
+++ b/lib/opened-captions.js
@@ -26,7 +26,7 @@ module.exports = (function() {
     options = options || {};
 
     // Default options
-    this.options = Utils._.extend({
+    this.options = Object.assign({
       io: null,
       port: 8080
     }, options);

--- a/lib/opened-captions.js
+++ b/lib/opened-captions.js
@@ -4,8 +4,7 @@ var express = require('express'),
   http = require('http'),
   socketio = require('socket.io'),
   Message = require('./message'),
-  Promise = require('bluebird'),
-  Utils = require('./utils');
+  Promise = require('bluebird');
 
 /**
  * This is the main class, the entry point to opened captions. To use it, you just need to import opened captions:

--- a/lib/streams/abstract/index.js
+++ b/lib/streams/abstract/index.js
@@ -7,7 +7,7 @@ var AbstractStream = function(oc, options) {
   options = options || {};
 
   // Default options
-  this.metadata = _.extend({
+  this.metadata = Object.assign({
     id: uuid.v4(),
     description: ''
   }, options);
@@ -107,7 +107,7 @@ AbstractStream.prototype.getBuffer = function(cursor) {
 AbstractStream.prototype.trimBuffer = function() {
 
   // Get the lowest cursor value
-  var cursorValues = _.values(this.cursors);
+  var cursorValues = Object.values(this.cursors);
   var index = Math.min.apply(null, cursorValues);
 
   // Slice off a portion (or all of) the content in the buffer

--- a/lib/streams/abstract/index.js
+++ b/lib/streams/abstract/index.js
@@ -1,7 +1,6 @@
 'use strict';
 
-var uuid = require('uuid'),
-  _ = require('lodash');
+var uuid = require('uuid');
 
 var AbstractStream = function(oc, options) {
   options = options || {};

--- a/lib/streams/network/index.js
+++ b/lib/streams/network/index.js
@@ -1,7 +1,6 @@
 'use strict';
 
 var AbstractStream = require('../abstract'),
-  Utils = require('../../utils'),
   net = require('net');
 
 var NetworkStream = function(oc, options) {

--- a/lib/streams/network/index.js
+++ b/lib/streams/network/index.js
@@ -14,7 +14,7 @@ var NetworkStream = function(oc, options) {
   options = options || {};
 
   // Default options
-  self.options = Utils._.extend({
+  self.options = Object.assign({
     host: 'localhost',
     port: 9000
   }, options);

--- a/lib/streams/server/index.js
+++ b/lib/streams/server/index.js
@@ -14,7 +14,7 @@ var ServerStream = function(oc, options) {
   options = options || {};
 
   // Default options
-  self.options = Utils._.extend({
+  self.options = Object.assign({
     host: 'localhost',
     port: 80
   }, options);

--- a/lib/streams/server/index.js
+++ b/lib/streams/server/index.js
@@ -1,7 +1,6 @@
 'use strict';
 
 var AbstractStream = require('../abstract'),
-  Utils = require('../../utils'),
   ioClient = require('socket.io-client');
 
 var ServerStream = function(oc, options) {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,7 +1,0 @@
-'use strict'
-
-var lodash = require('lodash')
-
-var Utils = module.exports = {
-  _: lodash
-}

--- a/package.json
+++ b/package.json
@@ -4,7 +4,6 @@
   "dependencies": {
     "bluebird": "^2.9.25",
     "express": "^4.12.3",
-    "lodash": "^3.8.0",
     "socket.io": "^2.1.1",
     "uuid": "^3.0.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -596,7 +596,6 @@ setprototypeof@1.1.0:
   resolved "https://registry.yarnpkg.com/setprototypeof/-/setprototypeof-1.1.0.tgz#d0bd85536887b6fe7c0d818cb962d9d91c54e656"
   integrity sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ==
 
-<<<<<<< HEAD
 should-equal@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/should-equal/-/should-equal-2.0.0.tgz#6072cf83047360867e68e98b09d71143d04ee0c3"
@@ -640,35 +639,6 @@ should@^13.2.3:
     should-type "^1.4.0"
     should-type-adaptors "^1.0.1"
     should-util "^1.0.0"
-=======
-should-equal@0.3.1:
-  version "0.3.1"
-  resolved "https://registry.yarnpkg.com/should-equal/-/should-equal-0.3.1.tgz#bd8ea97a6748e39fad476a3be6fd72ebc2e72bf0"
-  integrity sha1-vY6pemdI45+tR2o75v1y68LnK/A=
-  dependencies:
-    should-type "0.0.4"
-
-should-format@0.0.7:
-  version "0.0.7"
-  resolved "https://registry.yarnpkg.com/should-format/-/should-format-0.0.7.tgz#1e2ef86bd91da9c2e0412335b56ababd9a2fde12"
-  integrity sha1-Hi74a9kdqcLgQSM1tWq6vZov3hI=
-  dependencies:
-    should-type "0.0.4"
-
-should-type@0.0.4:
-  version "0.0.4"
-  resolved "https://registry.yarnpkg.com/should-type/-/should-type-0.0.4.tgz#0132a05417a6126866426acf116f1ed5623a5cd0"
-  integrity sha1-ATKgVBemEmhmQmrPEW8e1WI6XNA=
-
-should@^6.0.1:
-  version "6.0.3"
-  resolved "https://registry.yarnpkg.com/should/-/should-6.0.3.tgz#daee30786a557662fbc774c008d7c58791edb1d9"
-  integrity sha1-2u4weGpVdmL7x3TACNfFh5Htsdk=
-  dependencies:
-    should-equal "0.3.1"
-    should-format "0.0.7"
-    should-type "0.0.4"
->>>>>>> 1479ed6... Disconnect socket listener in tests
 
 socket.io-adapter@~1.1.0:
   version "1.1.1"


### PR DESCRIPTION
There are two very good reasons for removing lodash.

* The first is that we [don't need it](https://github.com/you-dont-need/You-Dont-Need-Lodash-Underscore)
* The second is that it was flagged as a dependency with a security vulnerability.

This PR removes the use of Lodash from the project and removes it from the list of package dependencies.

This is part of the efforts outlined in #15 