### PR TITLE
Remove bluebird

### DIFF
--- a/lib/opened-captions.js
+++ b/lib/opened-captions.js
@@ -1,9 +1,7 @@
 'use strict'
 
-var http = require('http'),
-  socketio = require('socket.io'),
-  Message = require('./message'),
-  Promise = require('bluebird');
+var socketio = require('socket.io'),
+  Message = require('./message');
 
 /**
  * This is the main class, the entry point to opened captions. To use it, you just need to import opened captions:

--- a/package.json
+++ b/package.json
@@ -2,7 +2,6 @@
   "name": "opened-captions",
   "version": "1.0.3",
   "dependencies": {
-    "bluebird": "^2.9.25",
     "socket.io": "^2.1.1",
     "uuid": "^3.0.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -57,11 +57,6 @@ blob@0.0.5:
   resolved "https://registry.yarnpkg.com/blob/-/blob-0.0.5.tgz#d680eeef25f8cd91ad533f5b01eed48e64caf683"
   integrity sha512-gaqbzQPqOoamawKg0LGVd7SzLgXS+JH61oWprSLH+P+abTczqJbhTR8CmJ2u9/bUYNmHTGJx/UEmn6doAvvuig==
 
-bluebird@^2.9.25:
-  version "2.11.0"
-  resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-2.11.0.tgz#534b9033c022c9579c56ba3b3e5a5caafbb650e1"
-  integrity sha1-U0uQM8AiyVecVro7Plpcqvu2UOE=
-
 brace-expansion@^1.1.7:
   version "1.1.11"
   resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.11.tgz#3c7fcbf529d87226f3d2f52b966ff5271eb441dd"


### PR DESCRIPTION
Bluebird is another relic from the past of this project, and is not
actually used anywhere.  This PR also sneaks out the import of the
http module since that isn't used either.

(Related to issue #15)